### PR TITLE
Var Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Role Variables
     rabbitmq_high_watermark_paging: 0.5
     # AWS Key config
     # Must set in your vars if you want to auto cluster
-    aws_access_key_id: not-a-real-key
-    aws_secret_access_key: not-a-real-key
+    app_settings:
+      rabbitmq:
+        aws_access_key_id: not-a-real-key
+        aws_secret_access_key: not-a-real-key
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,5 +33,7 @@ tag_value: rabbitmq
 user_home_folder: /root
 
 # AWS Key config
-aws_access_key_id: not-a-real-key
-aws_secret_access_key: not-a-real-key
+app_settings:
+  rabbitmq:
+    aws_access_key_id: not-a-real-key
+    aws_secret_access_key: not-a-real-key

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -9,8 +9,8 @@
     key: Name
     value: rabbitmq
   environment:
-    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
-    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_ACCESS_KEY_ID: "{{ app_settings['rabbitmq']['aws_access_key_id'] }}"
+    AWS_SECRET_ACCESS_KEY: "{{ app_settings['rabbitmq']['aws_secret_access_key'] }}"
   register: nodes
 
 - name: start rabbitmq-server (clustering)


### PR DESCRIPTION
Allow for easily setting different aws keys between environments when
using child roles.
