### PR TITLE
Ability to specify version and other improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@ rabbitmq_hostname: "{{ ansible_hostname }}.ec2.internal"
 rabbitmq_nodename_suffix: .ec2.internal
 rabbitmq_ec2_tag_key: Name
 rabbitmq_ec2_tag_value: rabbitmq
+# Either 'all' or specific region, e.g. 'eu-central-1'
+rabbitmq_ec2_region: all
 # Must be set to true for clustering to work
 rabbitmq_use_longname: "false"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,10 @@ rabbitmq_manage: true
 rabbitmq_cluster: false
 make_rabbitmq_user: true
 
+# Package versions
+erlang_version: "1:18.1"
+rabbitmq_version: "3.6.0-1"
+
 # Cluster information
 # RabbitMQ (erlang.cookie)
 rabbitmq_cookie: XPVTRGPZHAQYKQHKEBUF

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ rabbitmq_cluster: false
 make_rabbitmq_user: true
 
 # Package versions
+# !!! 'use_erlang_solutions_repo' should be set to true in order to specify erlang version !!!
+use_erlang_solutions_repo: false
 erlang_version: "1:18.1"
 rabbitmq_version: "3.6.0-1"
 

--- a/library/ec2_search.py
+++ b/library/ec2_search.py
@@ -17,7 +17,7 @@ options:
     aliases: []
   value:
     description:
-      - instance tag value in EC2
+      - instance tag value in EC2 (prefix)
     required: false
     default: null
     aliases: []
@@ -88,19 +88,17 @@ def get_all_ec2_regions(module):
         regions = boto.ec2.regions()
     except Exception, e:
         module.fail_json('Boto authentication issue: %s' % e)
-
     return regions
 
 # Connect to ec2 region
 def connect_to_region(region, module):
     try:
         conn = boto.ec2.connect_to_region(region)
+        if conn == None:
+            raise Exception("Unable to get connection from boto")
+        return conn
     except Exception, e:
-        print module.jsonify('error connecting to region: ' + region)
-        conn = None
-    # connect_to_region will fail "silently" by returning
-    # None if the region name is wrong or not supported
-    return conn
+        module.fail_json(msg='error connecting to region %s: %s' % (region, e))
 
 def main():
     module = AnsibleModule(
@@ -116,6 +114,9 @@ def main():
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
 
+    ec2_key = module.params.get('key')
+    ec2_value = module.params.get('value')
+
     server_info = list()
 
     all_regions = [r.name for r in get_all_ec2_regions(module)]
@@ -123,7 +124,7 @@ def main():
 
     # Check if passed region is correct
     if passed_region != 'all' and passed_region in all_regions:
-        regions = list(passed_region)
+        regions = [passed_region]
     else:
         regions = all_regions
 
@@ -132,16 +133,15 @@ def main():
         try:
             # Run when looking up by tag names, only returning hostname currently
             if module.params.get('lookup') == 'tags':
-                ec2_key = 'tag:' + module.params.get('key')
-                ec2_value = module.params.get('value')
-                reservations = conn.get_all_instances(filters={ec2_key : ec2_value})
-                for instance in [i for r in reservations for i in r.instances]:
-                    if instance.private_ip_address != None:
-                        instance.hostname = 'ip-' + instance.private_ip_address.replace('.', '-')
-                    if instance._state.name not in module.params.get('ignore_state'):
-                        server_info.append(todict(instance))
-        except:
-            print module.jsonify('error getting instances from: ' + region)
+                for instance in conn.get_only_instances():
+                    nameTag = instance.tags.get(ec2_key)
+                    if nameTag != None and nameTag.startswith(ec2_value):
+                        if instance.private_ip_address != None:
+                            instance.hostname = 'ip-' + instance.private_ip_address.replace('.', '-')
+                        if instance._state.name not in module.params.get('ignore_state'):
+                            server_info.append(todict(instance))
+        except Exception, e:
+            module.fail_json(msg='error getting instances from: %s %s' % (region, e))
 
     ec2_facts_result = dict(changed=True, info=server_info)
 

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -13,6 +13,7 @@
   ec2_search:
     key: "{{ rabbitmq_ec2_tag_key }}"
     value: "{{ rabbitmq_ec2_tag_value }}"
+    region: "{{ rabbitmq_ec2_region }}"
   environment:
     AWS_ACCESS_KEY_ID: "{{ app_settings['rabbitmq']['aws_access_key_id'] }}"
     AWS_SECRET_ACCESS_KEY: "{{ app_settings['rabbitmq']['aws_secret_access_key'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,26 @@
     name: "{{ rabbitmq_hostname }}"
   when: rabbitmq_cluster
 
+- name: add erlang key (Ubuntu/Debian)
+  apt_key:
+    url: http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
+    state: present
+  when: ansible_os_family == 'Debian'
+
+- name: add erlang repo (Ubuntu)
+  apt_repository:
+    repo: "deb http://packages.erlang-solutions.com/ubuntu {{ ansible_distribution_release }} contrib"
+    state: present
+    update_cache: yes
+  when: ansible_distribution == 'Ubuntu'
+
+- name: add erlang repo (Debian)
+  apt_repository:
+    repo: deb http://packages.erlang-solutions.com/debian wheezy contrib
+    state: present
+    update_cache: yes
+  when: ansible_distribution == 'Debian'
+
 - name: add rabbitmq key (Debian)
   apt_key:
     url: http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
@@ -20,9 +40,12 @@
 
 - name: install packages
   apt:
-    name: rabbitmq-server
+    name: "{{ item }}"
     state: present
   when: ansible_os_family == 'Debian'
+  with_items:
+    - esl-erlang={{ erlang_version }}
+    - rabbitmq-server={{ rabbitmq_version }}
 
 - name: shutdown rabbitmq to change cookie and conf file
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,21 +9,21 @@
   apt_key:
     url: http://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
     state: present
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and use_erlang_solutions_repo
 
 - name: add erlang repo (Ubuntu)
   apt_repository:
     repo: "deb http://packages.erlang-solutions.com/ubuntu {{ ansible_distribution_release }} contrib"
     state: present
     update_cache: yes
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' and use_erlang_solutions_repo
 
 - name: add erlang repo (Debian)
   apt_repository:
     repo: deb http://packages.erlang-solutions.com/debian wheezy contrib
     state: present
     update_cache: yes
-  when: ansible_distribution == 'Debian'
+  when: ansible_distribution == 'Debian' and use_erlang_solutions_repo
 
 - name: add rabbitmq key (Debian)
   apt_key:
@@ -38,14 +38,20 @@
     update_cache: yes
   when: ansible_os_family == 'Debian'
 
-- name: install packages
+- name: install packages (Erlang Solutions repo enabled)
   apt:
     name: "{{ item }}"
     state: present
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and use_erlang_solutions_repo
   with_items:
     - esl-erlang={{ erlang_version }}
     - rabbitmq-server={{ rabbitmq_version }}
+
+- name: install packages (Ubuntu default repo is used)
+  apt:
+    name: "rabbitmq-server"
+    state: present
+  when: ansible_os_family == 'Debian' and not use_erlang_solutions_repo
 
 - name: shutdown rabbitmq to change cookie and conf file
   service:


### PR DESCRIPTION
- Add ability to specify EC2 region
  - 'all' is default, meaning look in all available regions
- Fail fast on boto errors
  - If boto unable to connect to region
  - If there are errors in main loop
- Add ability to specify erlang version (via Erlang Solutions repo)
- Add ability to specify rabbitmq version
- Tag search is now by prefix
  - Useful when you're naming your instances like:
    - rabbit-1
    - rabbit-2
