### PR TITLE
CentOS and possibly other OS's supported

### DIFF
--- a/library/ec2_search.py
+++ b/library/ec2_search.py
@@ -147,11 +147,11 @@ def main():
                     if nameTag is not None and nameTag.startswith(ec2_value):
                         if instance.private_ip_address is not None:
                             instance.hostname = 'ip-' + instance.private_ip_address.replace('.', '-')
+                            if write_hosts_entries:
+                                if instance.private_ip_address not in filter((lambda line: re.match('^[0-9]', line)), map((lambda line: re.split('\s+', line)[0]), hosts_lines.splitlines())):
+                                    hosts_fp.write("%s %s\n" % (instance.private_ip_address, instance.hostname))
                         if instance._state.name not in module.params.get('ignore_state') and instance.hostname != socket.gethostname().split('.')[0]:
                             server_info.append(todict(instance))
-                        if write_hosts_entries:
-                            if instance.private_ip_address not in filter((lambda line: re.match('^[0-9]', line)), map((lambda line: re.split('\s+', line)[0]), hosts_lines.splitlines())):
-                                hosts_fp.write("%s %s\n" % (instance.private_ip_address, instance.hostname))
         except Exception as e:
             module.fail_json(msg='error getting instances from: %s %s' % (region, e))
 

--- a/library/ec2_search.py
+++ b/library/ec2_search.py
@@ -88,7 +88,7 @@ def todict(obj, classkey=None):
 def get_all_ec2_regions(module):
     try:
         regions = boto.ec2.regions()
-    except Exception, e:
+    except Exception as e:
         module.fail_json('Boto authentication issue: %s' % e)
     return regions
 
@@ -97,10 +97,10 @@ def get_all_ec2_regions(module):
 def connect_to_region(region, module):
     try:
         conn = boto.ec2.connect_to_region(region)
-        if conn == None:
+        if conn is None:
             raise Exception("Unable to get connection from boto")
         return conn
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg='error connecting to region %s: %s' % (region, e))
 
 
@@ -139,12 +139,12 @@ def main():
             if module.params.get('lookup') == 'tags':
                 for instance in conn.get_only_instances():
                     nameTag = instance.tags.get(ec2_key)
-                    if nameTag != None and nameTag.startswith(ec2_value):
-                        if instance.private_ip_address != None:
+                    if nameTag is not None and nameTag.startswith(ec2_value):
+                        if instance.private_ip_address is not None:
                             instance.hostname = 'ip-' + instance.private_ip_address.replace('.', '-')
                         if instance._state.name not in module.params.get('ignore_state'):
                             server_info.append(todict(instance))
-        except Exception, e:
+        except Exception as e:
             module.fail_json(msg='error getting instances from: %s %s' % (region, e))
 
     ec2_facts_result = dict(changed=True, info=server_info)

--- a/library/ec2_search.py
+++ b/library/ec2_search.py
@@ -59,7 +59,7 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-
+import socket
 
 def todict(obj, classkey=None):
     if isinstance(obj, dict):
@@ -142,7 +142,7 @@ def main():
                     if nameTag is not None and nameTag.startswith(ec2_value):
                         if instance.private_ip_address is not None:
                             instance.hostname = 'ip-' + instance.private_ip_address.replace('.', '-')
-                        if instance._state.name not in module.params.get('ignore_state'):
+                        if instance._state.name not in module.params.get('ignore_state') and instance.hostname != socket.gethostname().split('.')[0]:
                             server_info.append(todict(instance))
         except Exception as e:
             module.fail_json(msg='error getting instances from: %s %s' % (region, e))

--- a/library/ec2_search.py
+++ b/library/ec2_search.py
@@ -60,6 +60,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+
 def todict(obj, classkey=None):
     if isinstance(obj, dict):
         data = {}
@@ -75,13 +76,14 @@ def todict(obj, classkey=None):
         # debugging. If it's useful later I'll look into it.
         if not isinstance(obj, boto.ec2.blockdevicemapping.BlockDeviceType):
             data = dict([(key, todict(value, classkey))
-                for key, value in obj.__dict__.iteritems()
-                if not callable(value) and not key.startswith('_')])
+                        for key, value in obj.__dict__.iteritems()
+                        if not callable(value) and not key.startswith('_')])
             if classkey is not None and hasattr(obj, "__class__"):
                 data[classkey] = obj.__class__.__name__
             return data
     else:
         return obj
+
 
 def get_all_ec2_regions(module):
     try:
@@ -89,6 +91,7 @@ def get_all_ec2_regions(module):
     except Exception, e:
         module.fail_json('Boto authentication issue: %s' % e)
     return regions
+
 
 # Connect to ec2 region
 def connect_to_region(region, module):
@@ -99,6 +102,7 @@ def connect_to_region(region, module):
         return conn
     except Exception, e:
         module.fail_json(msg='error connecting to region %s: %s' % (region, e))
+
 
 def main():
     module = AnsibleModule(

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -94,6 +94,9 @@ galaxy_info:
     - name: Debian
       versions:
         - all
+    - name: CentOS
+      versions:
+        - 6
   #
   # Below are all categories currently available. Just as with
   # the platforms above, uncomment those that apply to your role.

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -14,9 +14,9 @@
     key: "{{ rabbitmq_ec2_tag_key }}"
     value: "{{ rabbitmq_ec2_tag_value }}"
     region: "{{ rabbitmq_ec2_region }}"
-  environment:
-    AWS_ACCESS_KEY_ID: "{{ app_settings['rabbitmq']['aws_access_key_id'] }}"
-    AWS_SECRET_ACCESS_KEY: "{{ app_settings['rabbitmq']['aws_secret_access_key'] }}"
+  # environment:
+  #   AWS_ACCESS_KEY_ID: "{{ app_settings['rabbitmq']['aws_access_key_id'] }}"
+  #   AWS_SECRET_ACCESS_KEY: "{{ app_settings['rabbitmq']['aws_secret_access_key'] }}"
   register: nodes
 
 - name: start rabbitmq-server (clustering)

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -14,6 +14,7 @@
     key: "{{ rabbitmq_ec2_tag_key }}"
     value: "{{ rabbitmq_ec2_tag_value }}"
     region: "{{ rabbitmq_ec2_region }}"
+    write_hosts_entries: "{{ rabbitmq_write_hosts_entries }}"
     # Security best practices recommend applying a IAM instacnce role rather than
     # a user. Boto will pick up the credentials from the role. Uncomment the following
     # only if all you have is a user supplied access/secret key pair

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -14,6 +14,9 @@
     key: "{{ rabbitmq_ec2_tag_key }}"
     value: "{{ rabbitmq_ec2_tag_value }}"
     region: "{{ rabbitmq_ec2_region }}"
+    # Security best practices recommend applying a IAM instacnce role rather than
+    # a user. Boto will pick up the credentials from the role. Uncomment the following
+    # only if all you have is a user supplied access/secret key pair
   # environment:
   #   AWS_ACCESS_KEY_ID: "{{ app_settings['rabbitmq']['aws_access_key_id'] }}"
   #   AWS_SECRET_ACCESS_KEY: "{{ app_settings['rabbitmq']['aws_secret_access_key'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,12 @@
     state: present
   when: ansible_os_family == 'Debian' and not use_erlang_solutions_repo
 
+- name: install packages (RedHat/CentOS default repo)
+  yum:
+    name: "rabbitmq-server"
+    state: present
+  when: ansible_os_family == 'RedHat'
+
 - name: shutdown rabbitmq to change cookie and conf file
   service:
     name: rabbitmq-server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,17 +47,11 @@
     - esl-erlang={{ erlang_version }}
     - rabbitmq-server={{ rabbitmq_version }}
 
-- name: install packages (Ubuntu default repo is used)
-  apt:
+- name: install packages (when default repo is used)
+  package:
     name: "rabbitmq-server"
     state: present
-  when: ansible_os_family == 'Debian' and not use_erlang_solutions_repo
-
-- name: install packages (RedHat/CentOS default repo)
-  yum:
-    name: "rabbitmq-server"
-    state: present
-  when: ansible_os_family == 'RedHat'
+  when: not use_erlang_solutions_repo
 
 - name: shutdown rabbitmq to change cookie and conf file
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,8 +74,10 @@
 
 - name: enable management plugin
   rabbitmq_plugin:
-     name: rabbitmq_management
-     state: enabled
+    name: rabbitmq_management
+    new_only: yes
+    state: enabled
+  notify: restart rabbitmq-server
   when: rabbitmq_manage
 
 - name: Setup rabbitmq user with admin access
@@ -93,5 +95,7 @@
 - name: Enable plugins
   rabbitmq_plugin:
     names: "{{ rabbitmq_plugins }}"
+    new_only: yes
     state: enabled
+  notify: restart rabbitmq-server
   when: rabbitmq_plugins is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,3 +89,9 @@
     tags: "{{ rabbitmq_default_user_tags }}"
     state: "{{ rabbitmq_user_state }}"
   when: make_rabbitmq_user
+
+- name: Enable plugins
+  rabbitmq_plugin:
+    names: "{{ rabbitmq_plugins }}"
+    state: enabled
+  when: rabbitmq_plugins is defined


### PR DESCRIPTION
While tasked to get this to work with CentOS the major change required was to go from using apt to yum. Since the package names are the same between the OS's the package module can be used to cover both cases. I have tested this on CentOS 6, but I believe it would work on more modern releases as well.

In the library file I added a check to remove attempted clustering to itself, which always fails with an error. The 'socket' module is imported to do a self hostname lookup.

Also in the library file I quieted some pycodestyle notifications. Some of which do nothing other than remove the warnings. While ```except Exception, e:``` would not run within python 2.6.6 which required syntax to be: ```except Exception as e:``` I have not tried on other version of python.

Thanks for providing the foundation to get rabbitmq clustered. I found it to be useful for my project.